### PR TITLE
chore: remove duplicate global style import

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -3,7 +3,6 @@ import '../styles/globals.scss';        // puis ton SCSS
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import '@/styles/globals.scss'
 export default function RootLayout({ children }) {
   return (
     <html lang="fr">


### PR DESCRIPTION
## Summary
- remove duplicate `globals.scss` import from layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689fa6671f408324a79a69a61d4e925a